### PR TITLE
Change viewport size so it's not so close to double the tile size

### DIFF
--- a/src/tiler/Tiler.tsx
+++ b/src/tiler/Tiler.tsx
@@ -3,7 +3,7 @@ import { getTilePath } from "./getTile";
 
 const MAX_ZOOM = 3;
 
-const VIEWPORT_SIZE = 500;
+const VIEWPORT_SIZE = 400;
 
 const Tiler: React.FC = () => {
   const [zoom, setZoom] = React.useState(1);


### PR DESCRIPTION
Change viewport size so it's not so close to double the tile size. This can lead to confusion.